### PR TITLE
Add Flubu to .NET Open Source Developer Projects - Flubu is A C# build automation tool for building projects and executing deployment scripts using C# code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2221,3 +2221,4 @@ A curated list of awesome C-Sharp frameworks, libraries and software.
 * [kubiix/ReSharper.StyleCop](https://github.com/kubiix/ReSharper.StyleCop) - StyleCop support for ReSharper
 * [reuzel/CqlSharp](https://github.com/reuzel/CqlSharp) - An ADO.Net driver for Cassandra
 * [dotMorten/SharpGIS.GZipWebClient](https://github.com/dotMorten/SharpGIS.GZipWebClient) - GZip WebClient for Windows Phone
+* [FlubuCore](https://github.com/flubu-core/flubu.core) -Fluent builder is A C# library for building projects and executing deployment scripts using C# code.


### PR DESCRIPTION
github: https://github.com/flubu-core/flubu.core

**Flubu main features / advantages**

- Net Core support (works also on linux and macOS).
- Easy to learn and to use because you write build script entirely in C#.
- Quite a lot of built in tasks (compile, running tests, managing iis, creating deploy package, publishing nuget packages, executing powershell scripts...)
- Write your own custom c# code in script and execute it.
- Run any external program in script.
- Reference any .net library or c# source code file in buildscript.
- Fluent interface and intelisense.
- Write tests, debug your build script.
- Use flubu tasks in any other application.
- Web api is available for flubu. Useful for automated deployments remotely.
- Write your own flubu tasks and extend flubu fluent interface with them.