### PR TITLE
Add llmdot to awesome-c-sharp

### DIFF
--- a/README.md
+++ b/README.md
@@ -840,3 +840,4 @@ A curated list of awesome C-Sharp frameworks, libraries and software.
 * [FlingOS/FlingOS](https://github.com/FlingOS/FlingOS) - An educational operating system written in C#. A great stepping stone from high to low level development.
 * [BloodHoundAD/SharpHound3](https://github.com/BloodHoundAD/SharpHound3) - C# Data Collector for the BloodHound Project, Version 3
 * [csinn/CSharp-From-Zero-To-Hero](https://github.com/csinn/CSharp-From-Zero-To-Hero) - C# boot camp
+* [cognisoc/llmdot](https://github.com/cognisoc/llmdot) - One NuGet package to run local GGUF language models from .NET (C#) — bindings over llama.cpp.


### PR DESCRIPTION
## Summary
- Add [cognisoc/llmdot](https://github.com/cognisoc/llmdot) — a one-package .NET binding for running local GGUF language models.

## About llmdot
llmdot is a single NuGet package that brings local LLM inference to .NET applications via bindings over llama.cpp. Targets .NET 6+/8+, supports GGUF-format models, and ships a managed API surface — no external native binaries to wire up.

- License: MIT
- Repo: https://github.com/cognisoc/llmdot
- Topics: csharp, dotnet, llm, gguf, llama-cpp, local-inference