### PR TITLE
Add maximn/google-maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -840,3 +840,4 @@ A curated list of awesome C-Sharp frameworks, libraries and software.
 * [FlingOS/FlingOS](https://github.com/FlingOS/FlingOS) - An educational operating system written in C#. A great stepping stone from high to low level development.
 * [BloodHoundAD/SharpHound3](https://github.com/BloodHoundAD/SharpHound3) - C# Data Collector for the BloodHound Project, Version 3
 * [csinn/CSharp-From-Zero-To-Hero](https://github.com/csinn/CSharp-From-Zero-To-Hero) - C# boot camp
+* [maximn/google-maps](https://github.com/maximn/google-maps) - Strongly-typed, async .NET wrapper for the Google Maps web service APIs (Geocoding, Routes, Distance Matrix, Places, Elevation, Time Zone, and more)


### PR DESCRIPTION
Adds **maximn/google-maps** (GoogleMapsApi) — a strongly-typed, async .NET wrapper for the Google Maps web service APIs (Geocoding, Routes, Directions, Distance Matrix, Places, Elevation, Time Zone, Address Validation, Static Maps).

Actively maintained, 2M+ NuGet downloads, multi-targets net10.0/net8.0/netstandard2.0, BSD-2-Clause.

NuGet: https://www.nuget.org/packages/GoogleMapsApi/